### PR TITLE
Update to log4j version 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
+### V2.1.3
+
+- Fixed vulnerability CVE-2021-45105
+- Update to log4j version 2.17.0
+
+
 ### V2.1.2
 
-- Fixed vulnerability CVE-2021-44228
+- Fixed vulnerability CVE-2021-45046
 - Update to log4j version 2.16.0
 
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mvn install
 <dependency>
     <groupId>com.api.util</groupId>
     <artifactId>ApiSecurity</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
 </dependency>
 ```
  
@@ -76,12 +76,12 @@ mvn install
 <dependency>
 	<groupId>org.apache.logging.log4j</groupId>
 	<artifactId>log4j-api</artifactId>
-	<version>2.16.0</version>
+	<version>2.17.0</version>
 </dependency>
 <dependency>
 	<groupId>org.apache.logging.log4j</groupId>
 	<artifactId>log4j-core</artifactId>
-	<version>2.16.0</version>
+	<version>2.17.0</version>
 </dependency>
 ```
 
@@ -125,7 +125,7 @@ gradle test jacocoTestReport
 ```
 
 The compiled _jar_ file will be located in the **build/libs** folder
-+ java-apex-api-security-2.1.1.jar
++ java-apex-api-security-2.1.3.jar
 
 Import this jar into your java classpath to use the utility class
 
@@ -140,7 +140,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    compile group: 'com.api.util', name: 'ApiSecurity', version: '2.1.1'
+    compile group: 'com.api.util', name: 'ApiSecurity', version: '2.1.3'
 }
 	
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 
-version '2.1.2'
+version '2.1.3'
 
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
@@ -20,8 +20,8 @@ dependencies {
     
     //gradle 4.0
     compile group: 'commons-lang', name: 'commons-lang', version: '2.4'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69'

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.api.util</groupId>
   <artifactId>ApiSecurity</artifactId>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <build>
     <plugins>
       <plugin>
@@ -80,12 +80,12 @@
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.16.0</version>
+		    <version>2.17.0</version>
 	</dependency>
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.16.0</version>
+		    <version>2.17.0</version>
 	</dependency>
   	<dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
# Description

- Fixed vulnerability CVE-2021-45105
- Update to log4j version 2.17.0

## Type of change

Please delete options that are not relevant.

- [x] Security patch
