### PR TITLE
Vulnerabilities fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### V2.1.4
+
+- Fixed vulnerability CVE-2021-44832, CWE-400
+- Update to log4j version 2.17.1
+- Update to jackson-databind version 2.12.6
+
 ### V2.1.3
 
 - Fixed vulnerability CVE-2021-45105

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ dependencies {
     
     //gradle 4.0
     compile group: 'commons-lang', name: 'commons-lang', version: '2.4'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6.1'
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69'
     
@@ -30,7 +30,7 @@ dependencies {
 
     //gradle 6.9
     //implementation group: 'commons-lang', name: 'commons-lang', version: '2.4'
-    //implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    //implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6.1'
     //implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     //implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69'
     //testImplementation group: 'junit', name: 'junit', version: '4.13.1'

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.17.0</version>
+		    <version>2.17.1</version>
 	</dependency>
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.17.0</version>
+		    <version>2.17.1</version>
 	</dependency>
   	<dependency>
             <groupId>commons-lang</groupId>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>2.12.6</version>
         </dependency>
         <dependency>
 		    <groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
 		    <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
# Description

Fixed vulnerability [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)
Update to log4j version 2.17.1

Fixed vulnerability [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)
Fixed vulnerability [CVSS 5.9](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
Update to jackson-databind version 2.12.16.1


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [X] Security patch

## How Has This Been Tested?

Tested with mvn test

